### PR TITLE
Build wheels during unit test CI jobs and upload SLSA attestations

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -47,3 +47,45 @@ jobs:
         working-directory: ${{ github.workspace }}/test-runner
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
+
+  build:
+    name: Build wheel
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - "3.12"
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel build
+    - name: Build
+      run: |
+        python -m build .
+    - name: Get built filenames
+      id: filename
+      run: |
+        echo "tar=$(cd dist/ && echo *.tar.gz)" >> $GITHUB_OUTPUT
+        echo "whl=$(cd dist/ && echo *.tar.gz)" >> $GITHUB_OUTPUT
+    - name: Attest Build Provenance for tar
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-path: "dist/${{ steps.filename.outputs.tar }}"
+    - name: Attest Build Provenance for whl
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-path: "dist/${{ steps.filename.outputs.whl }}"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -16,6 +16,9 @@
 name: Test Runner Unit Tests
 on:
   push: null
+  pull_request:
+    branches:
+    - main
 permissions: read-all
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

We're working on ensuring all Intel repos are generating https://slsa.dev style evidence. See goto/securereuse for more details. Still in early stages of communicating what we're looking for. However, the gist of it is that we want to ensure all released artifacts have SLSA info in a transparency service where customers can verify it.

Related: https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/