### PR TITLE
Add ability to manually build all containers

### DIFF
--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -16,6 +16,7 @@ name: Weekly Tests
 on:
   schedule:
     - cron: "0 0 * * 0"
+  workflow_dispatch: null
 permissions: read-all
 jobs:
   get-groups:


### PR DESCRIPTION
## Description
Allow weekly tests to be run manually whenever.

## Related Issue
n/a

## Changes Made
Title

- [ ] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [ ] The documentation has been updated to reflect any changes in functionality.

## Validation
n/a

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
