### PR TITLE
Change Merge Check to action-wait-for-check

### DIFF
--- a/.github/workflows/merge_check.yaml
+++ b/.github/workflows/merge_check.yaml
@@ -20,21 +20,21 @@ jobs:
   status-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc
+      - uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be
         with:
+          checkName: helm-ci
           ref: ${{ github.event.merge_group.head_ref }}
-          check-name: helm-ci
-          repo-token: ${{ secrets.ACTION_TOKEN }}
-          wait-interval: 10
-      - uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc
+          timeoutSeconds: 1800
+          token: ${{ secrets.ACTION_TOKEN }}
+      - uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be
         with:
+          checkName: integration-test
           ref: ${{ github.event.merge_group.head_ref }}
-          check-name: integration-test
-          repo-token: ${{ secrets.ACTION_TOKEN }}
-          wait-interval: 10
-      - uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc
+          timeoutSeconds: 1800
+          token: ${{ secrets.ACTION_TOKEN }}
+      - uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be
         with:
+          checkName: coverage
           ref: ${{ github.event.merge_group.head_ref }}
-          check-name: coverage
-          repo-token: ${{ secrets.ACTION_TOKEN }}
-          wait-interval: 10
+          timeoutSeconds: 1800
+          token: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION
## Description
Merge Groups can't merge because `coverage` can't be detected by the method in the current workflow `Merge Check` that gives the status check.

## Related Issue
n/a

## Changes Made
Title

- [ ] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [ ] The documentation has been updated to reflect any changes in functionality.

## Validation
Must merge first.

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
