### PR TITLE
Pull cached serving container

### DIFF
--- a/test-runner/utils/test.py
+++ b/test-runner/utils/test.py
@@ -108,7 +108,7 @@ class Test(BaseModel):
         ) as serving_container:
             client_output = docker.run(
                 # Image
-                "python:3.11-slim-bullseye",
+                expandvars("${CACHE_REGISTRY}/cache/library/python:3.11-slim-bullseye"),
                 # Command
                 split(expandvars(self.cmd, nounset=True)),
                 # Stream Logs


### PR DESCRIPTION
## Description
When Test Runner has `serving: true`, it pulls a python container, but to avoid the pull rate limit we can use a cache registry instead.

## Related Issue
n/a

## Changes Made

- Update pull command in `serving_run`
- [x] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [x] No Intel Internal IP is present within the changes.
- [x] The documentation has been updated to reflect any changes in functionality.

## Validation

- [x] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
