### PR TITLE
Add Perf Repo to Infra

### DIFF
--- a/.github/workflows/container-ci.yaml
+++ b/.github/workflows/container-ci.yaml
@@ -221,6 +221,7 @@ jobs:
       uses: intel/ai-containers/test-runner@28ee014b2e4e9ffc4126d1b226691e5c72b75df5 # main
       with:
         cache_registry: ${{ secrets.CACHE_REGISTRY }}
+        perf_repo: ${{ secrets.PERF_REPO }}
         recipe_dir: ${{ inputs.group_dir }}
         registry: ${{ secrets.REGISTRY }}
         repo: ${{ secrets.REPO }}

--- a/.github/workflows/test-runner-ci.yaml
+++ b/.github/workflows/test-runner-ci.yaml
@@ -64,6 +64,8 @@ jobs:
       env:
         CACHE_REGISTRY: ${{ secrets.CACHE_REGISTRY }}
         FORCE_COLOR: 1
+        GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+        PERF_REPO: ${{ secrets.PERF_REPO }}
         REGISTRY: ${{ secrets.REGISTRY }}
         REPO: ${{ secrets.REPO }}
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
@@ -138,6 +140,7 @@ jobs:
       uses: intel/ai-containers/test-runner@28ee014b2e4e9ffc4126d1b226691e5c72b75df5 # main
       with:
         cache_registry: ${{ secrets.CACHE_REGISTRY }}
+        perf_repo: ${{ secrets.PERF_REPO }}
         recipe_dir: test-runner
         registry: ${{ secrets.REGISTRY }}
         repo: ${{ secrets.REPO }}

--- a/test-runner/action.yml
+++ b/test-runner/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Container Cache Registry URL'
     required: true
     type: string
+  perf_repo:
+    description: 'Performance Test Repo'
+    required: false
+    type: string
   recipe_dir:
     description: 'Path to Recipe Directory'
     required: false
@@ -59,6 +63,8 @@ runs:
       run: venv/bin/python mlops/test-runner/test_runner.py -f ${{ inputs.test_dir }}/tests.yaml -l ${{ inputs.test_dir }}/logs -a ${{ inputs.recipe_dir }}/.actions.json -v
       env:
         CACHE_REGISTRY: ${{ inputs.cache_registry }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+        PERF_REPO: ${{ inputs.perf_repo }}
         PYTHONPATH: mlops/test-runner
         REGISTRY: ${{ inputs.registry }}
         REPO: ${{ inputs.repo }}


### PR DESCRIPTION
## Description
Add the capability for the performance thresholds PR to utilize an internal repository

## Related Issue
MLOPS-1987

## Changes Made

- Update test runner composite with new ENV
- Update upwards-facing workflows
- [ ] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [ ] The documentation has been updated to reflect any changes in functionality.

## Validation
Next PR

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
