### PR TITLE
Exclude xpu-requirements.txt from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,8 @@ updates:
       pytorch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "xpu-requirements.txt"
     package-ecosystem: pip
     schedule:
       interval: weekly
@@ -52,6 +54,8 @@ updates:
       tensorflow:
         patterns:
           - "*"
+        exclude-patterns:
+          - "xpu-requirements.txt"
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,9 @@ updates:
   - directory: /pytorch
     groups:
       pytorch:
-        patterns:
-          - "*"
+        dependency-type: "development"
         exclude-patterns:
-          - "pytorch/xpu-requirements.txt"
+          - "xpu*"
     package-ecosystem: pip
     schedule:
       interval: weekly
@@ -52,10 +51,9 @@ updates:
   - directory: /tensorflow
     groups:
       tensorflow:
-        patterns:
-          - "*"
+        dependency-type: "development"
         exclude-patterns:
-          - "tensorflow/xpu-requirements.txt"
+          - "xpu*"
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "xpu-requirements.txt"
+          - "pytorch/xpu-requirements.txt"
     package-ecosystem: pip
     schedule:
       interval: weekly
@@ -55,7 +55,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "xpu-requirements.txt"
+          - "tensorflow/xpu-requirements.txt"
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/workflows/charts/action.yml
+++ b/workflows/charts/action.yml
@@ -71,3 +71,8 @@ runs:
         ct lint-and-install --config ${{ inputs.config_path }} ${{ inputs.config }}
       env:
         KUBECONFIG: /tmp/config.yaml
+    - name: Cleanup
+      if: always()
+      bash: shell
+      run: |
+        helm ls


### PR DESCRIPTION
## Description
Dependabot doesn't know the difference between xpu and cpu versions.

## Related Issue
n/a

## Changes Made

- Add `exclude-patterns`
- [ ] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [ ] The documentation has been updated to reflect any changes in functionality.

## Validation
TBD

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
