### PR TITLE
Fix intel python full installation

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -67,12 +67,12 @@ ENV PATH /opt/conda/envs/idp/bin:/opt/conda/condabin:/opt/conda/bin/:${PATH}
 ENV LD_LIBRARY_PATH /lib64/:/usr/lib64/:/usr/local/lib64:/opt/conda/envs/idp/lib:${LD_LIBRARY_PATH}
 
 RUN echo "conda activate idp" >> ~/.bashrc
-SHELL ["conda", "run", "-n", "idp", "/bin/bash", "-c"]
 
 WORKDIR /
 COPY idp-requirements.txt .
 
-RUN conda run -n idp python -m pip install --no-cache-dir -r idp-requirements.txt
+RUN conda install -y --file idp-requirements.txt && \
+    conda clean -y --all
 
 RUN ln -sf /opt/conda/envs/idp/bin/python /usr/local/bin/python && \
     ln -sf /opt/conda/envs/idp/bin/python /usr/local/bin/python3 && \


### PR DESCRIPTION
## Description
Change the idp installation command from `pip install` to `conda install` to avoid an issue.

## Related Issue
#177 

## Changes Made

- Remove shell declaration from cannibalizing `.bashrc` activation
- Switch from `pip install` to `conda install`
- [x] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [x] No Intel Internal IP is present within the changes.
- [x] The documentation has been updated to reflect any changes in functionality.

## Validation
Manual, since infra is still down.

- [x] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
