### PR TITLE
Fixed multinode entrypoint to exit properly

### DIFF
--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -123,8 +123,7 @@ set -e \n\
 set -a \n\
 source ~/.startup \n\
 set +a \n\
-eval \"\$@\" \n\
-tail -f /dev/null" >> /usr/local/bin/dockerd-entrypoint.sh && \
+eval \"\$@\"" >> /usr/local/bin/dockerd-entrypoint.sh && \
     chmod +x /usr/local/bin/dockerd-entrypoint.sh
 
 RUN echo 'HostKey /etc/ssh/ssh_host_dsa_key' > /var/run/sshd_config && \


### PR DESCRIPTION
This PR fixes the entrypoint in multinode stage of pytorch Dockerfile. Prior to this PR the entrypoint keeps running because of the tail command.