### PR TITLE
Minor doc fix for the PyTorch CPU jupyter image tag

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -97,7 +97,7 @@ docker run -it --rm \
     --net=host \
     -v $PWD/workspace:/workspace \
     -w /workspace \
-    intel/intel-extension-for-pytorch:xpu-jupyter
+    intel/intel-extension-for-pytorch:2.3.0-pip-jupyter
 ```
 
 After running the command above, copy the URL (something like `http://127.0.0.1:$PORT/?token=***`) into your browser to access the notebook server.


### PR DESCRIPTION
## Description
The example for the PyTorch CPU jupyter container is using the XPU container tag.

## Changes Made

* Updates the PyTorch README.md to fix the image tag in the CPU jupyter example. 

- [ ] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [x] The documentation has been updated to reflect any changes in functionality.

## Validation

I manually ran the example command on a clx machine.

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
