### PR TITLE
Use software.repos.intel.com Conda Channel

### DIFF
--- a/preset/classical-ml/Dockerfile
+++ b/preset/classical-ml/Dockerfile
@@ -64,7 +64,7 @@ RUN wget --progress=dot:giga --no-check-certificate https://github.com/conda-for
     export PATH="${CONDA_ROOT}/bin/:${PATH}" && \
     conda update -y conda && \
     conda config --add channels conda-forge && \
-    conda config --add channels intel && \
+    conda config --add channels https://software.repos.intel.com/python/conda/ && \
     conda init --all && \
     conda install -y \
         'jupyterlab>=4.1.8' \

--- a/preset/classical-ml/Dockerfile
+++ b/preset/classical-ml/Dockerfile
@@ -102,7 +102,6 @@ RUN conda create -yn classical-ml -c ${INTEL_CHANNEL} -c conda-forge \
         'python-dotenv>=1.0.1' \
         'tqdm>=4.66.2' \
         'matplotlib-base>=3.4.3' \
-        'dataset_librarian>=1.0.4' \
         'threadpoolctl>=3.3.0' \
         'ipython>=8.18.1' \
         'ipykernel>=6.29.3' \
@@ -116,6 +115,7 @@ RUN conda create -yn classical-ml -c ${INTEL_CHANNEL} -c conda-forge \
 
 # PyPI packages
 RUN conda run -n classical-ml python -m pip install --no-deps --no-cache-dir \
+    'dataset-librarian==1.0.4' \
     'cloud-data-connector==1.0.3'
 
 

--- a/preset/classical-ml/docker-compose.yaml
+++ b/preset/classical-ml/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
         BASE_TAG: ${BASE_TAG:-22.04}
         DPNP_VERSION: ${NUMBA_DPEX_VERSION:-0.14.0}
         IDP_VERSION: ${IDP_VERSION:-2024.1.0}
-        INTEL_CHANNEL: ${INTEL_CHANNEL:-intel}
+        INTEL_CHANNEL: ${INTEL_CHANNEL:-https://software.repos.intel.com/python/conda/}
         MINIFORGE_VERSION: ${MINIFORGE_VERSION:-Linux-x86_64}
         MODIN_VERSION: ${MODIN_VERSION:-0.26.1}
         MPI_VERSION: ${MPI_VERSION:-2021.12.0}

--- a/preset/data-analytics/Dockerfile
+++ b/preset/data-analytics/Dockerfile
@@ -98,7 +98,6 @@ RUN conda create -yn data-analytics -c "${INTEL_CHANNEL}" -c conda-forge \
         'python-dotenv>=1.0.1' \
         'tqdm>=4.66.2' \
         'matplotlib-base>=3.4.3' \
-        'dataset_librarian>=1.0.4' \
         'threadpoolctl>=3.3.0' \
         'ipython>=8.18.1' \
         'ipykernel>=6.29.3' \
@@ -110,6 +109,7 @@ RUN conda create -yn data-analytics -c "${INTEL_CHANNEL}" -c conda-forge \
     conda clean -y --all
 
 RUN conda run -n data-analytics python -m pip install --no-deps --no-cache-dir \
+    'dataset-librarian==1.0.4' \
     'cloud-data-connector==1.0.3'
 
 FROM data-analytics-python as data-analytics-jupyter

--- a/preset/data-analytics/Dockerfile
+++ b/preset/data-analytics/Dockerfile
@@ -65,7 +65,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
     export PATH="${CONDA_ROOT}/bin/:${PATH}" && \
     conda update -y conda && \
     conda config --add channels conda-forge && \
-    conda config --add channels intel && \
+    conda config --add channels https://software.repos.intel.com/python/conda/ && \
     conda init --all && \
     conda install -y \
         'jupyterlab>=4.1.8' \

--- a/preset/data-analytics/docker-compose.yaml
+++ b/preset/data-analytics/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
         BASE_TAG: ${BASE_TAG:-22.04}
         DPNP_VERSION: ${NUMBA_DPEX_VERSION:-0.14.0}
         IDP_VERSION: ${IDP_VERSION:-2024.1.0}
-        INTEL_CHANNEL: ${INTEL_CHANNEL:-intel}
+        INTEL_CHANNEL: ${INTEL_CHANNEL:-https://software.repos.intel.com/python/conda/}
         MINIFORGE_VERSION: ${MINIFORGE_VERSION:-Linux-x86_64}
         MODIN_VERSION: ${MODIN_VERSION:-0.26.1}
         MPI_VERSION: ${MPI_VERSION:-2021.12.0}

--- a/preset/deep-learning/Dockerfile
+++ b/preset/deep-learning/Dockerfile
@@ -137,7 +137,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
     export PATH="${CONDA_ROOT}/bin/:${PATH}" && \
     conda update -y conda && \
     conda config --add channels conda-forge && \
-    conda config --add channels intel && \
+    conda config --add channels https://software.repos.intel.com/python/conda/ && \
     conda init --all && \
     conda install -c conda-forge \
         'jupyterlab>=4.1.8' \
@@ -172,7 +172,7 @@ ARG TORCHAUDIO_CPU_VERSION
 ARG DEEPSPEED_VERSION
 
 # PyTorch CPU Env - conda packages
-RUN conda create -yn pytorch-cpu -c intel/label/oneapi -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda create -yn pytorch-cpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
         dpnp="${DPNP_VERSION}" \
         numpy="${NUMPY_VERSION}" \
         python="${PYTHON_VERSION}" \
@@ -227,7 +227,7 @@ ARG IDEX_VERSION
 ARG DEEPSPEED_VERSION
 
 # PyTorch GPU Env - conda packages
-RUN conda create -yn pytorch-gpu -c intel/label/oneapi -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda create -yn pytorch-gpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
         dpnp="${DPNP_VERSION}" \
         dpcpp-cpp-rt="${IDP_VERSION}" \
         mkl-dpcpp="${IDP_VERSION}" \
@@ -429,11 +429,11 @@ ENV UCX_TLS=ud,sm,self
 
 USER dev
 
-RUN conda install -n pytorch-cpu -c intel/label/oneapi -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda install -n pytorch-cpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
         deepspeed="${DEEPSPEED_VERSION}" \
         'tensorboardx>=2.6.2.2'
 
-RUN conda install -n pytorch-gpu -c intel/label/oneapi -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda install -n pytorch-gpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
         deepspeed="${DEEPSPEED_VERSION}" \
         'tensorboardx>=2.6.2.2'
 

--- a/preset/deep-learning/Dockerfile
+++ b/preset/deep-learning/Dockerfile
@@ -172,7 +172,7 @@ ARG TORCHAUDIO_CPU_VERSION
 ARG DEEPSPEED_VERSION
 
 # PyTorch CPU Env - conda packages
-RUN conda create -yn pytorch-cpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda create -yn pytorch-cpu -c "${INTEL_CHANNEL}" -c conda-forge \
         dpnp="${DPNP_VERSION}" \
         numpy="${NUMPY_VERSION}" \
         python="${PYTHON_VERSION}" \
@@ -227,7 +227,7 @@ ARG IDEX_VERSION
 ARG DEEPSPEED_VERSION
 
 # PyTorch GPU Env - conda packages
-RUN conda create -yn pytorch-gpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda create -yn pytorch-gpu -c "${INTEL_CHANNEL}" -c conda-forge \
         dpnp="${DPNP_VERSION}" \
         dpcpp-cpp-rt="${IDP_VERSION}" \
         mkl-dpcpp="${IDP_VERSION}" \
@@ -429,11 +429,11 @@ ENV UCX_TLS=ud,sm,self
 
 USER dev
 
-RUN conda install -n pytorch-cpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda install -n pytorch-cpu -c "${INTEL_CHANNEL}" -c conda-forge \
         deepspeed="${DEEPSPEED_VERSION}" \
         'tensorboardx>=2.6.2.2'
 
-RUN conda install -n pytorch-gpu -c https://software.repos.intel.com/python/conda -c "${INTEL_CHANNEL}" -c conda-forge \
+RUN conda install -n pytorch-gpu -c "${INTEL_CHANNEL}" -c conda-forge \
         deepspeed="${DEEPSPEED_VERSION}" \
         'tensorboardx>=2.6.2.2'
 

--- a/preset/deep-learning/Dockerfile
+++ b/preset/deep-learning/Dockerfile
@@ -199,8 +199,8 @@ RUN conda run -n pytorch-cpu pip install --no-deps --no-cache-dir --ignore-insta
         'ninja>=1.11.1.1' \
         'python-dotenv>=1.0.1' \
         'tqdm>=4.66.2' \
-        'cloud-data-connector>=1.0.3' \
-        'dataset-librarian>=1.0.4' && \
+        'cloud-data-connector==1.0.3' \
+        'dataset-librarian==1.0.4' && \
     conda run -n pytorch-cpu pip install --no-cache-dir --ignore-installed \
         'transformers>=4.40.2' \
         'datasets>=2.19.1' \
@@ -263,8 +263,8 @@ RUN conda run -n pytorch-gpu pip install --no-deps --no-cache-dir --ignore-insta
         'ninja>=1.11.1.1' \
         'python-dotenv>=1.0.1' \
         'tqdm>=4.66.2' \
-        'cloud-data-connector>=1.0.3' \
-        'dataset-librarian>=1.0.4' && \
+        'cloud-data-connector==1.0.3' \
+        'dataset-librarian==1.0.4' && \
     conda run -n pytorch-gpu pip install --no-cache-dir --ignore-installed \
         'transformers>=4.40.2' \
         'datasets>=2.19.1' \
@@ -306,7 +306,6 @@ RUN conda create -yn tensorflow-cpu -c "${INTEL_CHANNEL}" -c conda-forge \
         tensorflow="${TF_VERSION}" \
         impi-devel="${IMPI_VERSION}" \
         'matplotlib-base>=3.4.3' \
-        'dataset_librarian>=1.0.4' \
         'ipython>=8.18.1' \
         'ipykernel>=6.29.3' \
         'kernda>=0.3.0'  \
@@ -330,6 +329,7 @@ RUN conda run -n tensorflow-cpu pip install --no-cache-dir --ignore-installed \
 RUN conda run -n tensorflow-cpu pip install --no-deps --no-cache-dir --ignore-installed \
         'tensorflow-hub>=0.16.1' \
         'tqdm>=4.66.2' \
+        'dataset-librarian==1.0.4' \
         'cloud-data-connector>=1.0.3' && \
     conda clean -y --all
 
@@ -345,7 +345,6 @@ RUN conda create -yn tensorflow-gpu -c "${INTEL_CHANNEL}" -c conda-forge \
         tensorflow="${TF_VERSION}" \
         impi-devel="${IMPI_VERSION}" \
         'matplotlib-base>=3.4.3' \
-        'dataset_librarian>=1.0.4' \
         'ipython>=8.18.1' \
         'ipykernel>=6.29.3' \
         'kernda>=0.3.0' \
@@ -371,7 +370,8 @@ RUN conda run -n tensorflow-gpu pip install --no-cache-dir --ignore-installed \
 RUN conda run -n tensorflow-gpu pip install --no-deps --no-cache-dir --ignore-installed \
         'tensorflow-hub>=0.16.1' \
         'tqdm>=4.66.2' \
-        'cloud-data-connector>=1.0.3' && \
+        'dataset-librarian==1.0.4' \
+        'cloud-data-connector==1.0.3' && \
     conda clean -y --all
 
 FROM deep-learning-python as deep-learning-jupyter

--- a/preset/deep-learning/docker-compose.yaml
+++ b/preset/deep-learning/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
         ICD_VER: 23.43.27642.40-803~22.04
         IDP_VERSION: ${IDP_VERSION:-2024.1.0}
         IMPI_VERSION: ${IMPI_VERSION:-2021.12}
-        INTEL_CHANNEL: ${INTEL_CHANNEL:-intel}
+        INTEL_CHANNEL: ${INTEL_CHANNEL:-https://software.repos.intel.com/python/conda/}
         IPEX_CPU_VERSION: ${IPEX_CPU_VERSION:-2.2.0=*cpu*}
         IPEX_GPU_VERSION: ${IPEX_GPU_VERSION:-2.1.20=*xpu*}
         ITEX_VERSION: ${ITEX_VERSION:-2.15}

--- a/preset/inference-optimization/docker-compose.yaml
+++ b/preset/inference-optimization/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
         ICD_VER: 23.43.27642.40-803~22.04
         IDP_VERSION: ${IDP_VERSION:-2024.1.0}
         IMPI_VERSION: ${IMPI_VERSION:-2021.12}
-        INTEL_CHANNEL: ${INTEL_CHANNEL:-intel}
+        INTEL_CHANNEL: ${INTEL_CHANNEL:-https://software.repos.intel.com/python/conda/}
         IPEX_CPU_VERSION: ${IPEX_CPU_VERSION:-2.2.0=*cpu*}
         IPEX_GPU_VERSION: ${IPEX_GPU_VERSION:-2.1.20=*xpu*}
         ITEX_VERSION: ${ITEX_VERSION:-2.15}

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -55,7 +55,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
     ln -s /opt/conda ~/miniforge3 && \
     export PATH="/opt/conda/bin/:${PATH}" && \
     conda update -y conda && \
-    conda config --add channels intel && \
+    conda config --add channels https://software.repos.intel.com/python/conda/ && \
     conda create -yn idp \
     "intelpython3_${IDP_VERSION}" \
     "python=${PYTHON_VERSION}" && \

--- a/tensorflow/Dockerfile
+++ b/tensorflow/Dockerfile
@@ -257,7 +257,9 @@ RUN no_proxy="" NO_PROXY="" apt-get update && \
 ARG TF_VER="2.15.0"
 
 RUN conda install intel-extension-for-tensorflow=${TF_VER}=*xpu* \
-    -c intel/label/oneapi -c intel -c conda-forge
+    -c https://software.repos.intel.com/python/conda \
+    -c https://software.repos.intel.com/python/conda \
+    -c conda-forge
 
 ENV LD_LIBRARY_PATH=/opt/conda/envs/idp/lib:$LD_LIBRARY_PATH
 

--- a/tensorflow/Dockerfile
+++ b/tensorflow/Dockerfile
@@ -258,7 +258,6 @@ ARG TF_VER="2.15.0"
 
 RUN conda install intel-extension-for-tensorflow=${TF_VER}=*xpu* \
     -c https://software.repos.intel.com/python/conda \
-    -c https://software.repos.intel.com/python/conda \
     -c conda-forge
 
 ENV LD_LIBRARY_PATH=/opt/conda/envs/idp/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
## Description
anaconda.com/intel no longer exists, use the new channel url.

## Related Issue
n/a

## Changes Made

- [x] The code follows the project's [coding standards](../CONTRIBUTING.md#code-style).
- [x] No Intel Internal IP is present within the changes.
- [x] The documentation has been updated to reflect any changes in functionality.

## Validation

- [x] I have tested any changes in container groups locally with [`test_runner.py`](../test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
