### PR TITLE
Make Integration Tests status-check dependent on merge logs job

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -113,7 +113,7 @@ jobs:
         path: output.txt
         recreate: true
   status-check:
-    needs: [group-diff, pipeline-ci]
+    needs: [group-diff, pipeline-ci, merge-logs]
     runs-on: ${{ github.repository_owner == 'intel' && 'intel-ubuntu-latest' || 'ubuntu-latest' }}
     if: always()
     steps:


### PR DESCRIPTION
## Description
Title

## Related Issue
n/a

## Changes Made

- [ ] The code follows the project's [coding standards](https://github.com/intel/ai-containers/blob/main/CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [ ] The documentation has been updated to reflect any changes in functionality.

## Validation
n/a

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
