### PR TITLE
Compare against same Python Version

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -32,7 +32,7 @@ In the previous command, you should see a result at the bottom like: `Time Consu
 # Use the working directory from the above command
 docker run --rm -it \
     -v $PWD/tests:/tests \
-    python:3.11-slim-bullseye \
+    python:3.10-slim-bullseye \
     bash
 pip install numpy
 python /tests/perf_sample.py


### PR DESCRIPTION
## Description
It doesn't make sense to compare 3.11 vs. 3.10 in stock vs. intel python perf comparison.

## Related Issue
n/a

## Changes Made

- [ ] The code follows the project's [coding standards](https://github.com/intel/ai-containers/blob/main/CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [ ] The documentation has been updated to reflect any changes in functionality.

## Validation

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
