### PR TITLE
IPEX XPU 2.3.110 support

### DIFF
--- a/python/docker-compose.yaml
+++ b/python/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
     build:
       args:
         MINIFORGE_VERSION: ${MINIFORGE_VERSION:-Linux-x86_64}
+        no_proxy: ""
       context: .
       labels:
         dependency.apt.wget: true

--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -167,26 +167,11 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf  /var/lib/apt/lists/*
 
-RUN no_proxy=$no_proxy wget -q  -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
-   | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \
-   echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
-   | tee /etc/apt/sources.list.d/oneAPI.list
-
-ARG DPCPP_VER
-ARG MKL_VER
-ARG CCL_VER
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends --fix-missing \
-    intel-oneapi-runtime-dpcpp-cpp=${DPCPP_VER} \
-    intel-oneapi-runtime-mkl=${MKL_VER} \
-    intel-oneapi-runtime-ccl=${CCL_VER};
-
-RUN rm -rf /etc/apt/sources.list.d/intel-gpu-jammy.list /etc/apt/sources.list.d/oneAPI.list
+RUN rm -rf /etc/apt/sources.list.d/intel-gpu-jammy.list
 
 ENV LD_LIBRARY_PATH=/opt/intel/oneapi/redist/lib:$LD_LIBRARY_PATH
 
-FROM ipex-xpu-base AS ipex-xpu-base-wheels
+FROM ipex-xpu-base AS ipex-xpu-base-wheels-pip
 
 WORKDIR /
 COPY xpu-requirements.txt .
@@ -194,7 +179,15 @@ COPY xpu-requirements.txt .
 RUN python -m pip install --no-cache-dir -r xpu-requirements.txt && \
     rm -rf xpu-requirements.txt
 
-FROM ipex-xpu-base AS ipex-xpu-jupyter
+FROM ipex-xpu-base AS ipex-xpu-base-wheels-idp
+
+WORKDIR /
+COPY xpu-requirements.txt .
+
+RUN conda run -n idp python -m pip install --no-cache-dir -r xpu-requirements.txt && \
+    rm -rf xpu-requirements.txt
+
+FROM ipex-xpu-base-wheels-${PACKAGE_OPTION} AS ipex-xpu-jupyter
 
 WORKDIR /jupyter
 COPY jupyter-requirements.txt .

--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -169,7 +169,7 @@ RUN apt-get update && \
 
 RUN rm -rf /etc/apt/sources.list.d/intel-gpu-jammy.list
 
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/redist/lib:$LD_LIBRARY_PATH
+ENV OCL_ICD_VENDORS=/etc/OpenCL/vendors
 
 FROM ipex-xpu-base AS ipex-xpu-base-wheels-pip
 

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -272,6 +272,13 @@ The images below are [TorchServe*] with CPU Optimizations:
 
 For more details, follow the procedure in the [TorchServe](https://github.com/pytorch/serve/blob/master/examples/intel_extension_for_pytorch/README.md) instructions.
 
+The images below are [TorchServe*] with XPU Optimizations:
+
+| Tag(s)              | Pytorch  | IPEX         | Dockerfile      |
+| ------------------- | -------- | ------------ | --------------- |
+| `2.3.110-serving-xpu` | [v2.3.1] | [v2.3.110+xpu] | [v0.4.0-Beta]   |
+
+
 ## CPU only images with Intel® Distribution for Python*
 
 The images below are built only with CPU optimizations (GPU acceleration support was deliberately excluded) and include [Intel® Distribution for Python*]:

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -24,7 +24,7 @@ The images below include support for both CPU and GPU optimizations:
 
 | Tag(s)                 | Pytorch  | IPEX           | Driver | Dockerfile      |
 | ---------------------- | -------- | -------------- | ------ | --------------- |
-| `2.3.110-xpu-pip-base`,`2.3.110-xpu` | [v2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta]   |
+| `2.3.110-xpu-pip-base`,`2.3.110-xpu` | [V2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta]   |
 | `2.1.40-xpu-pip-base`,`2.1.40-xpu`   | [v2.1.0] | [v2.1.40+xpu]  | [914]  | [v0.4.0-Beta]   |
 | `2.1.30-xpu`           | [v2.1.0] | [v2.1.30+xpu]  | [803]  | [v0.4.0-Beta]   |
 | `2.1.20-xpu`           | [v2.1.0] | [v2.1.20+xpu]  | [803]  | [v0.3.4]        |
@@ -47,7 +47,7 @@ The images below additionally include [Jupyter Notebook](https://jupyter.org/) s
 
 | Tag(s)                | Pytorch  | IPEX          | Driver | Jupyter Port | Dockerfile      |
 | --------------------- | -------- | ------------- | ------ | ------------ | --------------- |
-| `2.3.110-xpu-pip-jupyter` | [v2.3.1] | [v2.3.110+xpu] | [950]  | `8888`     | [v0.4.0-Beta]   |
+| `2.3.110-xpu-pip-jupyter` | [V2.3.1] | [v2.3.110+xpu] | [950]  | `8888`     | [v0.4.0-Beta]   |
 | `2.1.40-xpu-pip-jupyter` | [v2.1.0] | [v2.1.40+xpu] | [914]  | `8888`     | [v0.4.0-Beta]   |
 | `2.1.20-xpu-pip-jupyter` | [v2.1.0] | [v2.1.20+xpu] | [803]  | `8888`    | [v0.3.4]        |
 | `2.1.10-xpu-pip-jupyter` | [v2.1.0] | [v2.1.10+xpu] | [736]  | `8888`    | [v0.2.3]        |
@@ -276,8 +276,7 @@ The images below are [TorchServe*] with XPU Optimizations:
 
 | Tag(s)              | Pytorch  | IPEX         | Dockerfile      |
 | ------------------- | -------- | ------------ | --------------- |
-| `2.3.110-serving-xpu` | [v2.3.1] | [v2.3.110+xpu] | [v0.4.0-Beta]   |
-
+| `2.3.110-serving-xpu` | [V2.3.1] | [v2.3.110+xpu] | [v0.4.0-Beta]   |
 
 ## CPU only images with Intel® Distribution for Python*
 
@@ -317,7 +316,7 @@ The images below are built only with CPU and GPU optimizations and include [Inte
 
 | Tag(s)           | Pytorch  | IPEX         | Driver | Dockerfile      |
 | ---------------- | -------- | ------------ | -------- | ------ |
-| `2.3.110-xpu-idp-base` | [v2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta] |
+| `2.3.110-xpu-idp-base` | [V2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta] |
 | `2.1.40-xpu-idp-base` | [v2.1.0] | [v2.1.40+xpu] | [914]  | [v0.4.0-Beta] |
 | `2.1.30-xpu-idp-base` | [v2.1.0] | [v2.1.30+xpu]  | [803]  | [v0.4.0-Beta] |
 | `2.1.10-xpu-idp-base` | [v2.1.0] | [v2.1.10+xpu]  | [736]  | [v0.2.3] |
@@ -326,7 +325,7 @@ The images below additionally include [Jupyter Notebook](https://jupyter.org/) s
 
 | Tag(s)                | Pytorch  | IPEX          | Driver | Jupyter Port | Dockerfile      |
 | --------------------- | -------- | ------------- | ------ | ------------ | --------------- |
-| `2.3.110-xpu-idp-jupyter` | [v2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta] |
+| `2.3.110-xpu-idp-jupyter` | [V2.3.1] | [v2.3.110+xpu] | [950]  | `8888` | [v0.4.0-Beta] |
 | `2.1.40-xpu-idp-jupyter` | [v2.1.0] | [v2.1.40+xpu] | [914]  | `8888`   | [v0.4.0-Beta]   |
 | `2.1.20-xpu-idp-jupyter` | [v2.1.0] | [v2.1.20+xpu] | [803]  | `8888`   | [v0.3.4]        |
 | `2.1.10-xpu-idp-jupyter` | [v2.1.0] | [v2.1.10+xpu] | [736]  | `8888`   | [v0.2.3]        |
@@ -404,7 +403,7 @@ It is the image user's responsibility to ensure that any use of The images below
 
 [v2.4.0]: https://github.com/pytorch/pytorch/releases/tag/v2.4.0
 [v2.3.0]: https://github.com/pytorch/pytorch/releases/tag/v2.3.0
-[v2.3.1]: https://github.com/pytorch/pytorch/tree/v2.3.1
+[V2.3.1]: https://github.com/pytorch/pytorch/tree/v2.3.1
 [v2.2.2]: https://github.com/pytorch/pytorch/releases/tag/v2.2.2
 [v2.2.0]: https://github.com/pytorch/pytorch/releases/tag/v2.2.0
 [v2.1.2]: https://github.com/pytorch/pytorch/releases/tag/v2.1.2

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -24,7 +24,7 @@ The images below include support for both CPU and GPU optimizations:
 
 | Tag(s)                 | Pytorch  | IPEX           | Driver | Dockerfile      |
 | ---------------------- | -------- | -------------- | ------ | --------------- |
-| `2.3.110-xpu-pip-base`,`2.3.110-xpu` | [V2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta]   |
+| `2.3.110-xpu-pip-base`,`2.3.110-xpu` | [V2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0]   |
 | `2.1.40-xpu-pip-base`,`2.1.40-xpu`   | [v2.1.0] | [v2.1.40+xpu]  | [914]  | [v0.4.0-Beta]   |
 | `2.1.30-xpu`           | [v2.1.0] | [v2.1.30+xpu]  | [803]  | [v0.4.0-Beta]   |
 | `2.1.20-xpu`           | [v2.1.0] | [v2.1.20+xpu]  | [803]  | [v0.3.4]        |

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -24,7 +24,8 @@ The images below include support for both CPU and GPU optimizations:
 
 | Tag(s)                 | Pytorch  | IPEX           | Driver | Dockerfile      |
 | ---------------------- | -------- | -------------- | ------ | --------------- |
-| `2.1.40-xpu-pip-base`,`2.1.40-xpu`           | [v2.1.0] | [v2.1.40+xpu]  | [914]  | [v0.4.0-Beta]   |
+| `2.3.110-xpu-pip-base`,`2.3.110-xpu` | [v2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta]   |
+| `2.1.40-xpu-pip-base`,`2.1.40-xpu`   | [v2.1.0] | [v2.1.40+xpu]  | [914]  | [v0.4.0-Beta]   |
 | `2.1.30-xpu`           | [v2.1.0] | [v2.1.30+xpu]  | [803]  | [v0.4.0-Beta]   |
 | `2.1.20-xpu`           | [v2.1.0] | [v2.1.20+xpu]  | [803]  | [v0.3.4]        |
 | `2.1.10-xpu`           | [v2.1.0] | [v2.1.10+xpu]  | [736]  | [v0.2.3]        |
@@ -37,7 +38,7 @@ docker run -it --rm \
     --device /dev/dri \
     -v /dev/dri/by-path:/dev/dri/by-path \
     --ipc=host \
-    intel/intel-extension-for-pytorch:2.1.40-xpu
+    intel/intel-extension-for-pytorch:2.3.110-xpu
 ```
 
 ---
@@ -46,6 +47,7 @@ The images below additionally include [Jupyter Notebook](https://jupyter.org/) s
 
 | Tag(s)                | Pytorch  | IPEX          | Driver | Jupyter Port | Dockerfile      |
 | --------------------- | -------- | ------------- | ------ | ------------ | --------------- |
+| `2.3.110-xpu-pip-jupyter` | [v2.3.1] | [v2.3.110+xpu] | [950]  | `8888`     | [v0.4.0-Beta]   |
 | `2.1.40-xpu-pip-jupyter` | [v2.1.0] | [v2.1.40+xpu] | [914]  | `8888`     | [v0.4.0-Beta]   |
 | `2.1.20-xpu-pip-jupyter` | [v2.1.0] | [v2.1.20+xpu] | [803]  | `8888`    | [v0.3.4]        |
 | `2.1.10-xpu-pip-jupyter` | [v2.1.0] | [v2.1.10+xpu] | [736]  | `8888`    | [v0.2.3]        |
@@ -57,7 +59,7 @@ docker run -it --rm \
     -p 8888:8888 \
     --device /dev/dri \
     -v /dev/dri/by-path:/dev/dri/by-path \
-    intel/intel-extension-for-pytorch:2.1.40-xpu-pip-jupyter
+    intel/intel-extension-for-pytorch:2.3.110-xpu-pip-jupyter
 ```
 
 After running the command above, copy the URL (something like `http://127.0.0.1:$PORT/?token=***`) into your browser to access the notebook server.
@@ -308,6 +310,7 @@ The images below are built only with CPU and GPU optimizations and include [Inte
 
 | Tag(s)           | Pytorch  | IPEX         | Driver | Dockerfile      |
 | ---------------- | -------- | ------------ | -------- | ------ |
+| `2.3.110-xpu-idp-base` | [v2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta] |
 | `2.1.40-xpu-idp-base` | [v2.1.0] | [v2.1.40+xpu] | [914]  | [v0.4.0-Beta] |
 | `2.1.30-xpu-idp-base` | [v2.1.0] | [v2.1.30+xpu]  | [803]  | [v0.4.0-Beta] |
 | `2.1.10-xpu-idp-base` | [v2.1.0] | [v2.1.10+xpu]  | [736]  | [v0.2.3] |
@@ -316,6 +319,7 @@ The images below additionally include [Jupyter Notebook](https://jupyter.org/) s
 
 | Tag(s)                | Pytorch  | IPEX          | Driver | Jupyter Port | Dockerfile      |
 | --------------------- | -------- | ------------- | ------ | ------------ | --------------- |
+| `2.3.110-xpu-idp-jupyter` | [v2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta] |
 | `2.1.40-xpu-idp-jupyter` | [v2.1.0] | [v2.1.40+xpu] | [914]  | `8888`   | [v0.4.0-Beta]   |
 | `2.1.20-xpu-idp-jupyter` | [v2.1.0] | [v2.1.20+xpu] | [803]  | `8888`   | [v0.3.4]        |
 | `2.1.10-xpu-idp-jupyter` | [v2.1.0] | [v2.1.10+xpu] | [736]  | `8888`   | [v0.2.3]        |
@@ -384,6 +388,7 @@ It is the image user's responsibility to ensure that any use of The images below
 [v0.2.3]: https://github.com/intel/ai-containers/blob/v0.2.3/pytorch/Dockerfile
 [v0.1.0]: https://github.com/intel/ai-containers/blob/v0.1.0/pytorch/Dockerfile
 
+[v2.3.110+xpu]: https://github.com/intel/intel-extension-for-pytorch/releases/tag/v2.3.110%2Bxpu
 [v2.1.40+xpu]: https://github.com/intel/intel-extension-for-pytorch/releases/tag/v2.1.40%2Bxpu
 [v2.1.30+xpu]: https://github.com/intel/intel-extension-for-pytorch/releases/tag/v2.1.30%2Bxpu
 [v2.1.20+xpu]: https://github.com/intel/intel-extension-for-pytorch/releases/tag/v2.1.20%2Bxpu
@@ -392,6 +397,7 @@ It is the image user's responsibility to ensure that any use of The images below
 
 [v2.4.0]: https://github.com/pytorch/pytorch/releases/tag/v2.4.0
 [v2.3.0]: https://github.com/pytorch/pytorch/releases/tag/v2.3.0
+[v2.3.1]: https://github.com/pytorch/pytorch/tree/v2.3.1
 [v2.2.2]: https://github.com/pytorch/pytorch/releases/tag/v2.2.2
 [v2.2.0]: https://github.com/pytorch/pytorch/releases/tag/v2.2.0
 [v2.1.2]: https://github.com/pytorch/pytorch/releases/tag/v2.1.2
@@ -422,6 +428,7 @@ It is the image user's responsibility to ensure that any use of The images below
 <!-- HuggingFace transformers releases -->
 [v4.44.0]: https://github.com/huggingface/transformers/releases/tag/v4.44.0
 
+[950]: https://dgpu-docs.intel.com/releases/stable_950_13_20240814.html
 [914]: https://dgpu-docs.intel.com/releases/stable_914_33_20240730.html
 [803]: https://dgpu-docs.intel.com/releases/LTS_803.29_20240131.html
 [736]: https://dgpu-docs.intel.com/releases/stable_736_25_20231031.html

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -24,7 +24,7 @@ The images below include support for both CPU and GPU optimizations:
 
 | Tag(s)                 | Pytorch  | IPEX           | Driver | Dockerfile      |
 | ---------------------- | -------- | -------------- | ------ | --------------- |
-| `2.3.110-xpu-pip-base`,`2.3.110-xpu` | [V2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0]   |
+| `2.3.110-xpu-pip-base`,`2.3.110-xpu` | [torch-2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0]   |
 | `2.1.40-xpu-pip-base`,`2.1.40-xpu`   | [v2.1.0] | [v2.1.40+xpu]  | [914]  | [v0.4.0-Beta]   |
 | `2.1.30-xpu`           | [v2.1.0] | [v2.1.30+xpu]  | [803]  | [v0.4.0-Beta]   |
 | `2.1.20-xpu`           | [v2.1.0] | [v2.1.20+xpu]  | [803]  | [v0.3.4]        |
@@ -47,7 +47,7 @@ The images below additionally include [Jupyter Notebook](https://jupyter.org/) s
 
 | Tag(s)                | Pytorch  | IPEX          | Driver | Jupyter Port | Dockerfile      |
 | --------------------- | -------- | ------------- | ------ | ------------ | --------------- |
-| `2.3.110-xpu-pip-jupyter` | [V2.3.1] | [v2.3.110+xpu] | [950]  | `8888`     | [v0.4.0-Beta]   |
+| `2.3.110-xpu-pip-jupyter` | [torch-2.3.1] | [v2.3.110+xpu] | [950]  | `8888`     | [v0.4.0-Beta]   |
 | `2.1.40-xpu-pip-jupyter` | [v2.1.0] | [v2.1.40+xpu] | [914]  | `8888`     | [v0.4.0-Beta]   |
 | `2.1.20-xpu-pip-jupyter` | [v2.1.0] | [v2.1.20+xpu] | [803]  | `8888`    | [v0.3.4]        |
 | `2.1.10-xpu-pip-jupyter` | [v2.1.0] | [v2.1.10+xpu] | [736]  | `8888`    | [v0.2.3]        |
@@ -276,7 +276,7 @@ The images below are [TorchServe*] with XPU Optimizations:
 
 | Tag(s)              | Pytorch  | IPEX         | Dockerfile      |
 | ------------------- | -------- | ------------ | --------------- |
-| `2.3.110-serving-xpu` | [V2.3.1] | [v2.3.110+xpu] | [v0.4.0-Beta]   |
+| `2.3.110-serving-xpu` | [torch-2.3.1] | [v2.3.110+xpu] | [v0.4.0-Beta]   |
 
 ## CPU only images with Intel® Distribution for Python*
 
@@ -316,7 +316,7 @@ The images below are built only with CPU and GPU optimizations and include [Inte
 
 | Tag(s)           | Pytorch  | IPEX         | Driver | Dockerfile      |
 | ---------------- | -------- | ------------ | -------- | ------ |
-| `2.3.110-xpu-idp-base` | [V2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta] |
+| `2.3.110-xpu-idp-base` | [torch-v2.3.1] | [v2.3.110+xpu] | [950]  | [v0.4.0-Beta] |
 | `2.1.40-xpu-idp-base` | [v2.1.0] | [v2.1.40+xpu] | [914]  | [v0.4.0-Beta] |
 | `2.1.30-xpu-idp-base` | [v2.1.0] | [v2.1.30+xpu]  | [803]  | [v0.4.0-Beta] |
 | `2.1.10-xpu-idp-base` | [v2.1.0] | [v2.1.10+xpu]  | [736]  | [v0.2.3] |
@@ -325,7 +325,7 @@ The images below additionally include [Jupyter Notebook](https://jupyter.org/) s
 
 | Tag(s)                | Pytorch  | IPEX          | Driver | Jupyter Port | Dockerfile      |
 | --------------------- | -------- | ------------- | ------ | ------------ | --------------- |
-| `2.3.110-xpu-idp-jupyter` | [v2.3.1] | [v2.3.110+xpu] | [950]  | `8888` | [v0.4.0-Beta] |
+| `2.3.110-xpu-idp-jupyter` | [torch-v2.3.1] | [v2.3.110+xpu] | [950]  | `8888` | [v0.4.0-Beta] |
 | `2.1.40-xpu-idp-jupyter` | [v2.1.0] | [v2.1.40+xpu] | [914]  | `8888`   | [v0.4.0-Beta]   |
 | `2.1.20-xpu-idp-jupyter` | [v2.1.0] | [v2.1.20+xpu] | [803]  | `8888`   | [v0.3.4]        |
 | `2.1.10-xpu-idp-jupyter` | [v2.1.0] | [v2.1.10+xpu] | [736]  | `8888`   | [v0.2.3]        |
@@ -403,13 +403,14 @@ It is the image user's responsibility to ensure that any use of The images below
 
 [v2.4.0]: https://github.com/pytorch/pytorch/releases/tag/v2.4.0
 [v2.3.0]: https://github.com/pytorch/pytorch/releases/tag/v2.3.0
-[V2.3.1]: https://github.com/pytorch/pytorch/tree/v2.3.1
 [v2.2.2]: https://github.com/pytorch/pytorch/releases/tag/v2.2.2
 [v2.2.0]: https://github.com/pytorch/pytorch/releases/tag/v2.2.0
 [v2.1.2]: https://github.com/pytorch/pytorch/releases/tag/v2.1.2
 [v2.1.0]: https://github.com/pytorch/pytorch/releases/tag/v2.1.0
 [v2.0.1]: https://github.com/pytorch/pytorch/releases/tag/v2.0.1
 [v2.0.0]: https://github.com/pytorch/pytorch/releases/tag/v2.0.0
+
+[torch-v2.3.1]: https://github.com/pytorch/pytorch/tree/v2.3.1
 
 [v3.0]: https://github.com/intel/neural-compressor/releases/tag/v3.0
 [v2.6]: https://github.com/intel/neural-compressor/releases/tag/v2.6

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -325,7 +325,7 @@ The images below additionally include [Jupyter Notebook](https://jupyter.org/) s
 
 | Tag(s)                | Pytorch  | IPEX          | Driver | Jupyter Port | Dockerfile      |
 | --------------------- | -------- | ------------- | ------ | ------------ | --------------- |
-| `2.3.110-xpu-idp-jupyter` | [V2.3.1] | [v2.3.110+xpu] | [950]  | `8888` | [v0.4.0-Beta] |
+| `2.3.110-xpu-idp-jupyter` | [v2.3.1] | [v2.3.110+xpu] | [950]  | `8888` | [v0.4.0-Beta] |
 | `2.1.40-xpu-idp-jupyter` | [v2.1.0] | [v2.1.40+xpu] | [914]  | `8888`   | [v0.4.0-Beta]   |
 | `2.1.20-xpu-idp-jupyter` | [v2.1.0] | [v2.1.20+xpu] | [803]  | `8888`   | [v0.3.4]        |
 | `2.1.10-xpu-idp-jupyter` | [v2.1.0] | [v2.1.10+xpu] | [736]  | `8888`   | [v0.2.3]        |

--- a/pytorch/docker-compose.yaml
+++ b/pytorch/docker-compose.yaml
@@ -94,13 +94,10 @@ services:
   xpu:
     build:
       args:
-        CCL_VER: ${CCL_VER:-2021.13.1-31}
-        DPCPP_VER: ${DPCPP_VER:-2024.2.1-1079}
-        ICD_VER: ${ICD_VER:-24.22.29735.27-914~22.04}
-        LEVEL_ZERO_DEV_VER: ${LEVEL_ZERO_DEV_VER:-1.17.6-914~22.04}
-        LEVEL_ZERO_GPU_VER: ${LEVEL_ZERO_GPU_VER:-1.3.29735.27-914~22.04}
-        LEVEL_ZERO_VER: ${LEVEL_ZERO_VER:-1.17.6-914~22.04}
-        MKL_VER: ${MKL_VER:-2024.2.1-103}
+        ICD_VER: ${ICD_VER:-24.26.30049.10-950~22.04}
+        LEVEL_ZERO_DEV_VER: ${LEVEL_ZERO_DEV_VER:-1.17.6-950~22.04}
+        LEVEL_ZERO_GPU_VER: ${LEVEL_ZERO_GPU_VER:-1.3.30049.10-950~22.04}
+        LEVEL_ZERO_VER: ${LEVEL_ZERO_VER:-1.17.6-950~22.04}
         NO_PROXY: ''
         PACKAGE_OPTION: ${PACKAGE_OPTION:-pip}
       labels:
@@ -109,51 +106,45 @@ services:
         dependency.apt.git: true
         dependency.apt.gnupg2: true
         dependency.apt.gpg-agent: true
-        dependency.apt.intel-level-zero-gpu: ${LEVEL_ZERO_GPU_VER:-1.3.29735.27-914~22.04}
-        dependency.apt.intel-oneapi-runtime-ccl: ${CCL_VER:-2021.13.1-31}
-        dependency.apt.intel-oneapi-runtime-dpcpp-cpp: ${DPCPP_VER:-2024.2.1-1079}
-        dependency.apt.intel-oneapi-runtime-mkl: ${MKL_VER:-2024.2.1-103}
-        dependency.apt.intel-opencl-icd: ${ICD_VER:-23.43.27642.40-803~22.04}
-        dependency.apt.level-zero: ${LEVEL_ZERO_VER:-1.17.6-914~22.04}
-        dependency.apt.level-zero-dev: ${LEVEL_ZERO_DEV_VER:-1.17.6-914~22.04}
+        dependency.apt.intel-level-zero-gpu: ${LEVEL_ZERO_GPU_VER:-1.3.30049.10-950~22.04}
+        dependency.apt.intel-opencl-icd: ${ICD_VER:-24.26.30049.10-950~22.04}
+        dependency.apt.level-zero: ${LEVEL_ZERO_VER:-1.17.6-950~22.04}
+        dependency.apt.level-zero-dev: ${LEVEL_ZERO_DEV_VER:-1.17.6-950~22.04}
         dependency.apt.rsync: true
         dependency.apt.unzip: true
         dependency.idp.pip: false
         org.opencontainers.base.name: "intel/python:3.10-core"
         org.opencontainers.image.title: "Intel® Extension for PyTorch XPU Base Image"
-        org.opencontainers.image.version: ${IPEX_VERSION:-2.1.40}-xpu-${PACKAGE_OPTION:-pip}-base
-      target: ipex-xpu-base-wheels
+        org.opencontainers.image.version: ${IPEX_VERSION:-2.3.110}-xpu-${PACKAGE_OPTION:-pip}-base
+      target: ipex-xpu-base-wheels-${PACKAGE_OPTION:-pip}
     command: >
       python -c "import torch;print(torch.device('xpu'));import
       intel_extension_for_pytorch as
-      ipex;print(ipex.xpu.is_available());print(torch.__version__);
+      ipex;print(torch.xpu.has_xpu());print(torch.__version__);
       print(ipex.__version__); [print(f'[{i}]:
-      {ipex.xpu.get_device_properties(i)}') for i in
-      range(ipex.xpu.device_count())];"
+      {torch.xpu.get_device_properties(i)}') for i in
+      range(torch.xpu.device_count())];"
     extends: ipex-base
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.1.40xpu}-xpu-base
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.3.110xpu}-xpu-base
   xpu-jupyter:
     build:
       args:
-        CCL_VER: ${CCL_VER:-2021.13.1-31}
-        DPCPP_VER: ${DPCPP_VER:-2024.2.1-1079}
-        ICD_VER: ${ICD_VER:-24.22.29735.27-914~22.04}
-        LEVEL_ZERO_DEV_VER: ${LEVEL_ZERO_DEV_VER:-1.17.6-914~22.04}
-        LEVEL_ZERO_GPU_VER: ${LEVEL_ZERO_GPU_VER:-1.3.29735.27-914~22.04}
-        LEVEL_ZERO_VER: ${LEVEL_ZERO_VER:-1.17.6-914~22.04}
-        MKL_VER: ${MKL_VER:-2024.2.1-103}
+        ICD_VER: ${ICD_VER:-24.26.30049.10-950~22.04}
+        LEVEL_ZERO_DEV_VER: ${LEVEL_ZERO_DEV_VER:-1.17.6-950~22.04}
+        LEVEL_ZERO_GPU_VER: ${LEVEL_ZERO_GPU_VER:-1.3.30049.10-950~22.04}
+        LEVEL_ZERO_VER: ${LEVEL_ZERO_VER:-1.17.6-950~22.04}
         NO_PROXY: ''
         PACKAGE_OPTION: ${PACKAGE_OPTION:-pip}
       labels:
         dependency.python.pip: jupyter-requirements.txt
-        org.opencontainers.base.name: "intel/intel-optimized-pytorch:${IPEX_VERSION:-2.1.40}-xpu-${PACKAGE_OPTION:-pip}-base"
+        org.opencontainers.base.name: "intel/intel-optimized-pytorch:${IPEX_VERSION:-2.3.110}-xpu-${PACKAGE_OPTION:-pip}-base"
         org.opencontainers.image.title: "Intel® Extension for PyTorch XPU Jupyter Image"
-        org.opencontainers.image.version: ${IPEX_VERSION:-2.1.40}-xpu-${PACKAGE_OPTION:-pip}-jupyter
+        org.opencontainers.image.version: ${IPEX_VERSION:-2.3.110}-xpu-${PACKAGE_OPTION:-pip}-jupyter
       target: ipex-xpu-jupyter
     command: >
       bash -c "python -m jupyter --version"
     extends: ipex-base
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.1.40xpu}-xpu-jupyter
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.3.110xpu}-xpu-jupyter
     ports:
       - 8888:8888
   torchserve-cpu:
@@ -196,7 +187,7 @@ services:
         docs: serving
         org.opencontainers.base.name: "intel/python:3.10-core"
         org.opencontainers.image.title: "Intel® Extension for PyTorch XPU Serving Image"
-        org.opencontainers.image.version: ${IPEX_VERSION:-2.1.40}-serving-xpu
+        org.opencontainers.image.version: ${IPEX_VERSION:-2.3.110}-serving-xpu
       target: torchserve-xpu
     command: torchserve --version
     entrypoint: ""

--- a/pytorch/notebooks/ipex-xpu.ipynb
+++ b/pytorch/notebooks/ipex-xpu.ipynb
@@ -25,13 +25,13 @@
    "outputs": [],
    "source": [
     "import intel_extension_for_pytorch as ipex\n",
-    "print(ipex.xpu.is_available())\n",
-    "if (not ipex.xpu.is_available()):\n",
+    "print(torch.xpu.has_xpu())\n",
+    "if (not torch.xpu.is_available()):\n",
     "    print('Intel GPU not detected. Please install GPU with compatible drivers')\n",
     "    sys.exit(1)\n",
-    "print(ipex.xpu.has_onemkl())\n",
+    "print(torch.xpu.has_onemkl())\n",
     "print(torch.__version__); print(ipex.__version__)\n",
-    "[print(f'[{i}]: {ipex.xpu.get_device_properties(i)}') for i in range(ipex.xpu.device_count())]\n"
+    "[print(f'[{i}]: {torch.xpu.get_device_properties(i)}') for i in range(torch.xpu.device_count())]\n"
    ]
   }
  ],

--- a/pytorch/serving/README.md
+++ b/pytorch/serving/README.md
@@ -39,7 +39,7 @@ docker run --rm -it \
            -u root \
            -v $PWD:/home/model-server \
            --device /dev/dri \
-           intel/intel-optimized-pytorch:2.1.40-serving-xpu \
+           intel/intel-optimized-pytorch:2.3.110-serving-xpu \
            sh -c 'python model-archive/ipex_squeezenet.py && \
            torch-model-archiver --model-name squeezenet1_1 \
            --version 1.1 \
@@ -73,7 +73,7 @@ docker run -d --rm --name server \
           -v $PWD/config-xpu.properties:/home/model-server/config.properties \
           --net=host \
           --device /dev/dri \
-          intel/intel-optimized-pytorch:2.1.40-serving-xpu
+          intel/intel-optimized-pytorch:2.3.110-serving-xpu
 ```
 
 After lauching the container, follow the steps below:

--- a/pytorch/serving/model-archive/ipex_squeezenet.py
+++ b/pytorch/serving/model-archive/ipex_squeezenet.py
@@ -27,8 +27,8 @@
 
 # pylint: skip-file
 
-import intel_extension_for_pytorch as ipex
 import torch
+import intel_extension_for_pytorch as ipex
 import torchvision.models as models
 
 # load the model

--- a/pytorch/serving/model-archive/ipex_squeezenet.py
+++ b/pytorch/serving/model-archive/ipex_squeezenet.py
@@ -27,8 +27,8 @@
 
 # pylint: skip-file
 
-import torch
 import intel_extension_for_pytorch as ipex
+import torch
 import torchvision.models as models
 
 # load the model

--- a/pytorch/serving/torchserve-xpu-requirements.txt
+++ b/pytorch/serving/torchserve-xpu-requirements.txt
@@ -1,9 +1,8 @@
-torch==2.1.0.post3+cxx11.abi
-torchvision==0.16.0.post3+cxx11.abi
-torchaudio==2.1.0.post3+cxx11.abi
-intel_extension_for_pytorch==2.1.40+xpu
+torch==2.3.1+cxx11.abi
+torchvision==0.18.1+cxx11.abi
+torchaudio==2.3.1+cxx11.abi
+intel_extension_for_pytorch==2.3.110+xpu
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us
-setuptools==69.5.1
 numpy==1.26.4
 captum>=0.7.0
 cython>=3.0.10

--- a/pytorch/serving/wf-store/rest-test.sh
+++ b/pytorch/serving/wf-store/rest-test.sh
@@ -33,13 +33,13 @@ apt-get -y install curl
 
 curl --fail -X GET http://localhost:8080/ping
 
-cd ../model-store || exit
+cd /home/model-server/model-store || exit
 curl --fail -O https://torchserve.pytorch.org/mar_files/cat_dog_classification.mar
 curl --fail -O https://torchserve.pytorch.org/mar_files/dog_breed_classification.mar
 curl --fail -X POST "http://127.0.0.1:8081/models?url=cat_dog_classification.mar"
 curl --fail -X POST "http://127.0.0.1:8081/models?url=dog_breed_classification.mar"
 
-cd ../wf-store || exit
+cd /home/model-server/wf-store || exit
 curl --fail -X POST "http://127.0.0.1:8081/workflows?url=dog_breed_wf.war"
 
 curl --fail -O https://raw.githubusercontent.com/pytorch/serve/master/examples/Workflows/dog_breed_classification/model_input/Cat.jpg

--- a/pytorch/tests/tests.yaml
+++ b/pytorch/tests/tests.yaml
@@ -16,14 +16,14 @@ import-ipex-cpu-${PACKAGE_OPTION:-pip}:
   img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.4.0}-base
   cmd: python -c "import torch;import intel_extension_for_pytorch as ipex;print(f'torch {torch.__version__} ipex {ipex.__version__}')"
 import-ipex-xpu-${PACKAGE_OPTION:-pip}:
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.1.40xpu}-xpu-base
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.3.110xpu}-xpu-base
   cmd: python -c "import torch; import intel_extension_for_pytorch as ipex;[print(f'[{i}] {torch.xpu.get_device_properties(i)}') for i in range(torch.xpu.device_count())];"
   device: ["/dev/dri"]
 import-cpu-jupyter-${PACKAGE_OPTION:-pip}:
   img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.4.0}-jupyter
   cmd: python -m jupyter --version
 import-xpu-jupyter-${PACKAGE_OPTION:-pip}:
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.1.40xpu}-xpu-jupyter
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.3.110xpu}-xpu-jupyter
   cmd: python -m jupyter --version
   device: ["/dev/dri"]
 import-cpu-oneccl-${PACKAGE_OPTION:-pip}:
@@ -46,14 +46,14 @@ ipex-cpu-${PACKAGE_OPTION:-pip}:
   - dst: /tests
     src: $PWD/pytorch/tests
 ipex-xpu-${PACKAGE_OPTION:-pip}:
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.1.40xpu}-xpu-base
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.3.110xpu}-xpu-base
   cmd: python /tests/ipex-resnet50.py --ipex --device xpu
   device: ["/dev/dri"]
   volumes:
   - dst: /tests
     src: $PWD/pytorch/tests
 ipex-xpu-jupyter-${PACKAGE_OPTION:-pip}:
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.1.40xpu}-xpu-jupyter
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-${BASE_IMAGE_NAME:-ubuntu}-${BASE_IMAGE_TAG:-22.04}-${PACKAGE_OPTION:-pip}-py${PYTHON_VERSION:-3.10}-ipex-${IPEX_VERSION:-2.3.110xpu}-xpu-jupyter
   cmd: papermill --log-output  /jupyter/xpu.ipynb -k python3
   device: ["/dev/dri"]
   notebook: True

--- a/pytorch/xpu-requirements.txt
+++ b/pytorch/xpu-requirements.txt
@@ -1,10 +1,9 @@
-torch==2.1.0.post3+cxx11.abi
-torchvision==0.16.0.post3+cxx11.abi
-torchaudio==2.1.0.post3+cxx11.abi
-intel_extension_for_pytorch==2.1.40+xpu
-oneccl_bind_pt==2.1.400+xpu
+torch==2.3.1+cxx11.abi
+torchvision==0.18.1+cxx11.abi
+torchaudio==2.3.1+cxx11.abi
+intel_extension_for_pytorch==2.3.110+xpu
+oneccl_bind_pt==2.3.100+xpu
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us
-setuptools==69.5.1
 numpy>=1.26.4
 idna>=3.7
 requests>=2.32.0


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes and the purpose of this pull request. Describe the expected behavior the changes intend to fix. -->
The PR adds support to updated IPEX XPU stack for 2.3.110 version.
## Related Issue
<!-- If this pull request is related to an issue or JIRA ticket, please link it here. -->
https://jira.devtools.intel.com/browse/MLOPS-2127
## Changes Made

- <!-- Describe the specific changes made in this pull request, including any new features, bug fixes, or enhancements. -->
- [x] The code follows the project's [coding standards](https://github.com/intel/ai-containers/blob/main/CONTRIBUTING.md#code-style).
- [x] No Intel Internal IP is present within the changes.
- [x] The documentation has been updated to reflect any changes in functionality.

## Validation
<!-- Explain how the changes have been tested, including the testing environment and any relevant test cases. -->

- [x] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.

```
Logs attached
```
[output_logs.zip](https://github.com/user-attachments/files/16969845/output_logs.zip)