### PR TITLE
 splitting command block

### DIFF
--- a/preset/README.md
+++ b/preset/README.md
@@ -75,7 +75,7 @@ docker run -it --rm \
 
 #### Next Steps
 
-1. For Deep Learning and Inference Optimization containers there will be separate conda environments for each AI framework: `pytorch-cpu`, `pytorch-gpu` and `tensorflow`. Use the command below to activate one environment:
+1. For Deep Learning and Inference Optimization containers there will be separate conda environments for each AI framework: `pytorch-cpu`, `pytorch-gpu`, `tensorflow-cpu` and `tensorflow-gpu`. Use the command below to activate one environment:
 
     ```bash
     conda activate <env-name>
@@ -84,10 +84,10 @@ docker run -it --rm \
 2. Select a test from the `sample-tests` folder and run it using the following command as an example:
 
     ```bash
-    bash sample-tests/onnx/run.sh
-    # or if no bash script is found
     python sample-tests/intel_extension_for_tensorflow/test_itex.py
     ```
+
+    Note: The `sample-tests` folder may differ in each container, and some tests use a bash script.
 
 ### Run using Jupyter Notebook
 

--- a/preset/README.md
+++ b/preset/README.md
@@ -87,7 +87,8 @@ docker run -it --rm \
     python sample-tests/intel_extension_for_tensorflow/test_itex.py
     ```
 
-    Note: The `sample-tests` folder may differ in each container, and some tests use a bash script.
+> [!NOTE]
+> The `sample-tests` folder may differ in each container, and some tests use a bash script.
 
 ### Run using Jupyter Notebook
 


### PR DESCRIPTION
## Description
Update Readme file for Preset Containers

## Related Issue
it is inconvenient for the user to have optional instructions in a single command block. The copy button copies the entire block making it necessary for user to update the command.

## Changes Made
Command block has one instruction. Now, the user can use the copy button with no additional step to use the command
