### PR TITLE
enable clinfo inside idp

### DIFF
--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -169,8 +169,6 @@ RUN apt-get update && \
 
 RUN rm -rf /etc/apt/sources.list.d/intel-gpu-jammy.list
 
-ENV OCL_ICD_VENDORS=/etc/OpenCL/vendors
-
 FROM ipex-xpu-base AS ipex-xpu-base-wheels-pip
 
 WORKDIR /
@@ -195,6 +193,7 @@ RUN python -m pip install --no-cache-dir -r jupyter-requirements.txt
 
 RUN if eval "which conda >/dev/null )"; then \
         echo "conda activate idp" >> ~/.bashrc; \
+        echo 'export OCL_ICD_VENDORS="/etc/OpenCL/vendors"' >> ~/.bashrc; \
     fi
 
 COPY --chown=root notebooks/ipex-xpu.ipynb /jupyter/xpu.ipynb

--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -185,6 +185,8 @@ COPY xpu-requirements.txt .
 RUN conda run -n idp python -m pip install --no-cache-dir -r xpu-requirements.txt && \
     rm -rf xpu-requirements.txt
 
+RUN echo 'export OCL_ICD_VENDORS="/etc/OpenCL/vendors"' >> ~/.bashrc
+
 FROM ipex-xpu-base-wheels-${PACKAGE_OPTION} AS ipex-xpu-jupyter
 
 WORKDIR /jupyter
@@ -193,7 +195,6 @@ RUN python -m pip install --no-cache-dir -r jupyter-requirements.txt
 
 RUN if eval "which conda >/dev/null )"; then \
         echo "conda activate idp" >> ~/.bashrc; \
-        echo 'export OCL_ICD_VENDORS="/etc/OpenCL/vendors"' >> ~/.bashrc; \
     fi
 
 COPY --chown=root notebooks/ipex-xpu.ipynb /jupyter/xpu.ipynb


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes and the purpose of this pull request. Describe the expected behavior the changes intend to fix. -->
This pull request enables `clinfo` detect Intel GPUs in a conda environment.
## Related Issue
<!-- If this pull request is related to an issue or JIRA ticket, please link it here. -->
https://jira.devtools.intel.com/browse/MLOPS-2148
## Changes Made

- <!-- Describe the specific changes made in this pull request, including any new features, bug fixes, or enhancements. -->
- [ ] The code follows the project's [coding standards](https://github.com/intel/ai-containers/blob/main/CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [ ] The documentation has been updated to reflect any changes in functionality.

## Validation
<!-- Explain how the changes have been tested, including the testing environment and any relevant test cases. -->

- [x] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
