### PR TITLE
Reuse PVC on TensorFlow Serving

### DIFF
--- a/workflows/charts/tensorflow-serving/Chart.yaml
+++ b/workflows/charts/tensorflow-serving/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/workflows/charts/tensorflow-serving/README.md
+++ b/workflows/charts/tensorflow-serving/README.md
@@ -2,7 +2,7 @@
 
 TensorFlow Serving is a flexible, high-performance serving system for machine learning models, designed for production environments. TensorFlow Serving makes it easy to deploy new algorithms and experiments, while keeping the same server architecture and APIs. TensorFlow Serving provides out-of-the-box integration with TensorFlow models, but can be easily extended to serve other types of models and data.
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 ## Installation
 
@@ -24,10 +24,12 @@ Then, follow the installation notes to test the deployment
 | deploy.resources.limits | object | `{"cpu":"4000m","gpu.intel.com/i915":1,"memory":"1Gi"}` | Maximum resources per pod |
 | deploy.resources.limits."gpu.intel.com/i915" | int | `1` | Intel GPU Device Configuration |
 | deploy.resources.requests | object | `{"cpu":"1000m","memory":"512Mi"}` | Minimum resources per pod |
-| deploy.storage.nfs | object | `{"enabled":false,"path":"nil","readOnly":true,"server":"nil"}` | Network File System (NFS) storage for models |
 | fullnameOverride | string | `""` | Full qualified Domain Name |
 | nameOverride | string | `""` | Name of the serving service |
+| pvc.create | bool | `false` | Create PVC instead of reuse |
+| pvc.name | string | `""` | Name of the PVC |
 | pvc.size | string | `"5Gi"` | Size of the storage |
+| pvc.storageClassName | string | `""` | Storage class name |
 | service.type | string | `"NodePort"` | Type of service |
 
 ----------------------------------------------

--- a/workflows/charts/tensorflow-serving/templates/deployment.yaml
+++ b/workflows/charts/tensorflow-serving/templates/deployment.yaml
@@ -58,27 +58,14 @@ spec:
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
-          {{- if .Values.deploy.storage.nfs.enabled }}
             - name: model
               mountPath: /models/{{ .Values.deploy.modelName }}
-          {{- else }}
-            - name: model
-              mountPath: /models/{{ .Values.deploy.modelName }}
-          {{- end }}
           resources:
             {{- toYaml .Values.deploy.resources | nindent 12 }}
       volumes:
         - name: dshm
           emptyDir:
             medium: Memory
-      {{- if .Values.deploy.storage.nfs.enabled }}
-        - name: model
-          nfs:
-            server: {{ .Values.deploy.storage.nfs.server }}
-            path: {{ .Values.deploy.storage.nfs.path }}
-            readOnly: {{ .Values.deploy.storage.nfs.readOnly }}
-      {{- else }}
         - name: model
           persistentVolumeClaim:
-            claimName: {{ include "tensorflow-serving.fullname" . }}-model-dir
-      {{- end }}
+            claimName: {{ .Values.pvc.name }}

--- a/workflows/charts/tensorflow-serving/templates/deployment.yaml
+++ b/workflows/charts/tensorflow-serving/templates/deployment.yaml
@@ -59,7 +59,8 @@ spec:
             - mountPath: /dev/shm
               name: dshm
             - name: model
-              mountPath: /models
+              mountPath: /models/
+              subPath: {{ .Values.deploy.modelName }}/saved_model
           resources:
             {{- toYaml .Values.deploy.resources | nindent 12 }}
       volumes:

--- a/workflows/charts/tensorflow-serving/templates/deployment.yaml
+++ b/workflows/charts/tensorflow-serving/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - mountPath: /dev/shm
               name: dshm
             - name: model
-              mountPath: /models/{{ .Values.deploy.modelName }}
+              mountPath: /models
           resources:
             {{- toYaml .Values.deploy.resources | nindent 12 }}
       volumes:

--- a/workflows/charts/tensorflow-serving/templates/pvc.yaml
+++ b/workflows/charts/tensorflow-serving/templates/pvc.yaml
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.pvc.create -}}
 ---
-{{- if not .Values.deploy.storage.nfs.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "tensorflow-serving.fullname" . }}-model-dir
+  name: {{ .Values.pvc.name }}
   labels:
     {{- include "tensorflow-serving.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.pvc.storageClassName }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   resources:

--- a/workflows/charts/tensorflow-serving/values.yaml
+++ b/workflows/charts/tensorflow-serving/values.yaml
@@ -38,16 +38,15 @@ deploy:
     requests:
       cpu: 1000m
       memory: 512Mi
-  storage:
-    # -- Network File System (NFS) storage for models
-    nfs:
-      enabled: false
-      server: nil
-      path: nil
-      readOnly: true
 service:
   # -- Type of service
   type: NodePort
 pvc:
+  # -- Create PVC instead of reuse
+  create: false
+  # -- Name of the PVC
+  name: ""
+  # -- Storage class name
+  storageClassName: ""
   # -- Size of the storage
   size: 5Gi


### PR DESCRIPTION
## Description
Instead of creating a new PVC or require reuse via NFS, let user reuse existing PVC

## Related Issue
MLOPS-2170

## Changes Made

- [x] The code follows the project's [coding standards](https://github.com/intel/ai-containers/blob/main/CONTRIBUTING.md#code-style).
- [x] No Intel Internal IP is present within the changes.
- [x] The documentation has been updated to reflect any changes in functionality.

## Validation
Validating on ITDC IKS

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
