### PR TITLE
Update XPU serving doc

### DIFF
--- a/pytorch/serving/README.md
+++ b/pytorch/serving/README.md
@@ -67,12 +67,19 @@ docker run -d --rm --name server \
 
 ```bash
 # Assuming that the above pre-archived model is in the current working directory
+## Find the video and render groups to add to the run command
+
+VIDEO=$(getent group video | sed -E 's,^video:[^:]*:([^:]*):.*$,\1,')
+RENDER=$(getent group render | sed -E 's,^render:[^:]*:([^:]*):.*$,\1,')
+
 docker run -d --rm --name server \
           -v $PWD:/home/model-server/model-store \
           -v $PWD/wf-store:/home/model-server/wf-store \
           -v $PWD/config-xpu.properties:/home/model-server/config.properties \
           --net=host \
           --device /dev/dri \
+          --group-add ${VIDEO} \
+          --group-add ${RENDER} \
           intel/intel-optimized-pytorch:2.5.10-serving-xpu
 ```
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes and the purpose of this pull request. Describe the expected behavior the changes intend to fix. -->
The additional detail ensures that a user's video and render groups are added to the docker environment. The default is GID=110 for render and 44 for video but can vary based on user's host. 

## Related Issue
<!-- If this pull request is related to an issue or JIRA ticket, please link it here. -->

## Changes Made

- <!-- Describe the specific changes made in this pull request, including any new features, bug fixes, or enhancements. -->
- [ ] The code follows the project's [coding standards](https://github.com/intel/ai-containers/blob/main/CONTRIBUTING.md#code-style).
- [ ] No Intel Internal IP is present within the changes.
- [x] The documentation has been updated to reflect any changes in functionality.

## Validation
<!-- Explain how the changes have been tested, including the testing environment and any relevant test cases. -->

- [ ] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
