### PR TITLE
Parametrize test file for test runner

### DIFF
--- a/test-runner/README.md
+++ b/test-runner/README.md
@@ -264,6 +264,11 @@ Inputs for the action:
     description: 'Path to Test Dir'
     required: true
     type: string
+  test_file:
+    description: 'Name of the test file to use'
+    required: false
+    type: string
+    default: 'tests.yaml'
   token:
     required: true
     type: string

--- a/test-runner/action.yml
+++ b/test-runner/action.yml
@@ -36,6 +36,11 @@ inputs:
     description: 'Path to Test Dir'
     required: true
     type: string
+  test_file:
+    description: 'Name of the test file to use'
+    required: false
+    type: string
+    default: 'tests.yaml'
   token:
     required: true
     type: string
@@ -56,7 +61,7 @@ runs:
           python -m pip install -r mlops/test-runner/requirements.txt
     - name: Test
       shell: bash
-      run: venv/bin/python mlops/test-runner/test_runner.py -f ${{ inputs.test_dir }}/tests.yaml -l ${{ inputs.test_dir }}/logs -a ${{ inputs.recipe_dir }}/.actions.json -v
+      run: venv/bin/python mlops/test-runner/test_runner.py -f ${{ inputs.test_dir }}/${{ inputs.test_file }} -l ${{ inputs.test_dir }}/logs -a ${{ inputs.recipe_dir }}/.actions.json -v
       env:
         CACHE_REGISTRY: ${{ inputs.cache_registry }}
         PYTHONPATH: mlops/test-runner


### PR DESCRIPTION
## Description
Tests file for tests runner is now parametrized

## Related Issue
No related issues

## Changes Made

- The test files to use by test runner action was hardcoded to "tests.yaml" with this change any file can be used for testing using test runner action. The parameter is optional and a default value of "tests.yaml" has been set to avoid any compatibility conflicts with any previously defined process/client.
- [ x ] The code follows the project's [coding standards](https://github.com/intel/ai-containers/blob/main/CONTRIBUTING.md#code-style).
- [ x ] No Intel Internal IP is present within the changes.
- [ x ] The documentation has been updated to reflect any changes in functionality.

## Validation
<!-- Explain how the changes have been tested, including the testing environment and any relevant test cases. -->

- [ x ] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
