### PR TITLE
Preset containers patch release 2025.1.0 -Bump from libexpat 2.6.4 to 2.7.0

### DIFF
--- a/preset/classical-ml/Dockerfile
+++ b/preset/classical-ml/Dockerfile
@@ -59,6 +59,7 @@ RUN wget --progress=dot:giga --no-check-certificate https://github.com/conda-for
         'jupyterlab>=4.2.6' \
         'notebook>=7.1.3' \
         'nb_conda_kernels>=2.5.1' \
+        'libexpat>=2.7.0' \
     && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
     && \
@@ -99,6 +100,7 @@ RUN conda create -yn classical-ml \
         "scikit-learn-intelex=${SKLEARNEX_VERSION}" \
         "xgboost=${XGBOOST_VERSION}" \
         "scikit-learn"=1.5.2 \
+        'libexpat>=2.7.0' \
         && \
     conda clean -y --all
 

--- a/preset/classical-ml/Dockerfile
+++ b/preset/classical-ml/Dockerfile
@@ -103,6 +103,7 @@ RUN conda create -yn classical-ml \
         "xgboost=${XGBOOST_VERSION}" \
         "scikit-learn"=1.5.2 \
         'libexpat>=2.7.0' \
+        'libxml2=2.13' \
         && \
     conda clean -y --all
 

--- a/preset/classical-ml/Dockerfile
+++ b/preset/classical-ml/Dockerfile
@@ -38,6 +38,8 @@ RUN apt-get update -y && \
         xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
+RUN apt-get remove libexpat1 -y
+
 # Setting up non-root directories
 RUN useradd --uid 1000 -d /home/dev -s /bin/bash -m dev
 USER dev

--- a/preset/classical-ml/docker-compose.yaml
+++ b/preset/classical-ml/docker-compose.yaml
@@ -64,7 +64,7 @@ services:
         dependency.conda.python: '==3.11.9'
         dependency.conda.scikit-learn-intelex: '==2025.0.1'
         dependency.conda.xgboost: '==2.1.1'
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
     environment:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}

--- a/preset/classical-ml/notebooks/modin/IntelModin_Vs_Pandas.ipynb
+++ b/preset/classical-ml/notebooks/modin/IntelModin_Vs_Pandas.ipynb
@@ -192,7 +192,7 @@
     "id": "ktbKmh_Kvy1o"
    },
    "source": [
-    "## applymap() method"
+    "## map() method"
    ]
   },
   {
@@ -209,7 +209,7 @@
    "outputs": [],
    "source": [
     "#Element-wise multiplication of each element by 2 using Pandas\n",
-    "%time p_df.applymap(lambda i:i*2)"
+    "%time p_df.map(lambda i:i*2)"
    ]
   },
   {
@@ -226,7 +226,7 @@
    "outputs": [],
    "source": [
     "#Element-wise multiplication of each element by 2 using Pandas\n",
-    "%time m_df.applymap(lambda i:i*2)"
+    "%time m_df.map(lambda i:i*2)"
    ]
   }
  ],

--- a/preset/classical-ml/tests.yaml
+++ b/preset/classical-ml/tests.yaml
@@ -15,23 +15,23 @@
 ---
 modin-${PYTHON_VERSION:-3.11}:
   cmd: conda run -n classical-ml sample-tests/modin/test_modin.sh
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   shm_size: 10.24G
 modin-notebook-${PYTHON_VERSION:-3.11}:
   cmd: papermill --log-output jupyter/modin/IntelModin_Vs_Pandas.ipynb -k classical-ml
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   notebook: True
 scikit-${PYTHON_VERSION:-3.11}:
   cmd: conda run -n classical-ml sample-tests/scikit/test_scikit.sh
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
 scikit-notebook-${PYTHON_VERSION:-3.11}:
   cmd: papermill --log-output jupyter/sklearn/Intel_Extension_For_SKLearn_GettingStarted.ipynb -k classical-ml
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   notebook: True
 xgboost-${PYTHON_VERSION:-3.11}:
   cmd: conda run -n classical-ml sample-tests/xgboost/test_xgboost.sh
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
 xgboost-notebook-${PYTHON_VERSION:-3.11}:
   cmd: papermill --log-output jupyter/xgboost/IntelPython_XGBoost_Performance.ipynb -k classical-ml
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-classical-ml-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   notebook: True

--- a/preset/deep-learning-jax-cpu/Dockerfile
+++ b/preset/deep-learning-jax-cpu/Dockerfile
@@ -58,6 +58,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
         'jupyterlab>=4.2.6' \
         'notebook>=7.1.3' \
         'nb_conda_kernels>=2.5.1' \
+        'libexpat>=2.7.0' \
     && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
     && \
@@ -94,6 +95,7 @@ RUN conda create -yn 'jax-cpu' \
         "mkl=${MKL_VERSION}" \
         'ipykernel>=6.29.5' \
         'kernda>=0.3.0' \
+        'libexpat>=2.7.0' \
         && \
     conda clean -y --all
 

--- a/preset/deep-learning-jax-cpu/Dockerfile
+++ b/preset/deep-learning-jax-cpu/Dockerfile
@@ -38,6 +38,8 @@ RUN apt-get update -y && \
         xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
+RUN apt-get remove libexpat1 -y
+
 RUN useradd --uid 1000 -d /home/dev -s /bin/bash -m dev
 USER dev
 WORKDIR /home/dev

--- a/preset/deep-learning-jax-cpu/docker-compose.yaml
+++ b/preset/deep-learning-jax-cpu/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
     depends_on:
       - dl-base
     extends: dl-base
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
     command: >
       bash -c "
       conda run -n jax-cpu python -c 'import jax; print(\"Jax Version:\", jax.__version__); import jax.numpy as jnp'

--- a/preset/deep-learning-jax-cpu/tests.yaml
+++ b/preset/deep-learning-jax-cpu/tests.yaml
@@ -14,14 +14,14 @@
 
 ---
 jax-import-${PYTHON_VERSION:-3.12}:
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   cmd: conda run -n jax-cpu python -c 'import jax; print("Jax Version:", jax.__version__); print(jax.devices())'
   device: ["/dev/dri"]
 jax-import-jupyter-${PYTHON_VERSION:-3.12}:
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   cmd: sh -c "python -m jupyter --version"
 jax-xpu-example-${PYTHON_VERSION:-3.12}:
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-jax-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   cmd: conda run -n jax-cpu python /tests/example.py
   device: ["/dev/dri"]
   volumes:

--- a/preset/deep-learning-pytorch-cpu/Dockerfile
+++ b/preset/deep-learning-pytorch-cpu/Dockerfile
@@ -73,6 +73,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
         'jupyterlab>=4.2.6' \
         'notebook>=7.1.3' \
         'nb_conda_kernels>=2.5.1' \
+        'libexpat>=2.7.0' \
     && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
     && \
@@ -125,6 +126,7 @@ RUN conda create -yn 'pytorch-cpu' \
         "onnxruntime=${ONNXRUNTIME_VERSION}" \
         "deepspeed=${DEEPSPEED_VERSION}" \
         'tensorboardx>=2.6.2.2' \
+        'libexpat>=2.7.0' \
         && \
     conda clean -y --all
 

--- a/preset/deep-learning-pytorch-cpu/Dockerfile
+++ b/preset/deep-learning-pytorch-cpu/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update -y && \
         xz-utils \
     && \
     rm -rf /var/lib/apt/lists/*
+RUN apt-get remove libexpat1 -y
 
 ##########################
 # Setting up non-root directories

--- a/preset/deep-learning-pytorch-cpu/docker-compose.yaml
+++ b/preset/deep-learning-pytorch-cpu/docker-compose.yaml
@@ -103,7 +103,7 @@ services:
     depends_on:
       - dl-base
     extends: dl-base
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
     command: >
       bash -c "
       conda run -n pytorch-cpu python -c 'import torch;print(torch.__version__);import intel_extension_for_pytorch as ipex;print(ipex.__version__);'

--- a/preset/deep-learning-pytorch-cpu/tests.yaml
+++ b/preset/deep-learning-pytorch-cpu/tests.yaml
@@ -15,18 +15,18 @@
 ---
 deep-learning-ipex-${PYTHON_VERSION:-3.11}-cpu:
   cmd: conda run -n pytorch-cpu python -W ignore sample-tests/intel_extension_for_pytorch/test_ipex.py --device cpu --ipex
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
 
 inference-optimization-inc-torch-${PYTHON_VERSION:-3.11}-cpu:
   cmd: conda run -n pytorch-cpu sample-tests/neural_compressor/run.sh cpu
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
 
 deep-learning-ipex-notebook-${PYTHON_VERSION:-3.11}-cpu:
   cmd: papermill --log-output jupyter/ipex/ResNet50_Inference.ipynb -k pytorch-cpu
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   notebook: True
 
 deep-learning-ipex-quantization-notebook-${PYTHON_VERSION:-3.11}-cpu:
   cmd: papermill --log-output jupyter/ipex-quantization/IntelPytorch_Quantization.ipynb -k pytorch-cpu
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   notebook: True

--- a/preset/deep-learning-pytorch-cpu/venv_requirements.txt
+++ b/preset/deep-learning-pytorch-cpu/venv_requirements.txt
@@ -1,2 +1,2 @@
 evaluate==0.4.3
-git+https://github.com/huggingface/optimum-intel.git
+optimum-intel

--- a/preset/deep-learning-pytorch-gpu/Dockerfile
+++ b/preset/deep-learning-pytorch-gpu/Dockerfile
@@ -103,6 +103,7 @@ RUN apt-get install -y --no-install-recommends --fix-missing \
         level-zero-dev="${LEVEL_ZERO_DEV_VER}" \
     && \
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/*list
+RUN apt-get remove libexpat1 -y
 
 ##########################
 # Setting up non-root directories

--- a/preset/deep-learning-pytorch-gpu/Dockerfile
+++ b/preset/deep-learning-pytorch-gpu/Dockerfile
@@ -133,6 +133,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
         'jupyterlab>=4.2.6' \
         'notebook>=7.1.3' \
         'nb_conda_kernels>=2.5.1' \
+        'libexpat>=2.7.0' \
     && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
     && \
@@ -180,6 +181,7 @@ RUN conda create -yn 'pytorch-gpu' \
         "torchvision=${TORCHVISION_XPU_VERSION}" \
         "deepspeed=${DEEPSPEED_VERSION}" \
         'tensorboardx=2.6.2.2' \
+        'libexpat>=2.7.0' \
         && \
     conda clean -y --all
 

--- a/preset/deep-learning-pytorch-gpu/docker-compose.yaml
+++ b/preset/deep-learning-pytorch-gpu/docker-compose.yaml
@@ -146,7 +146,7 @@ services:
     depends_on:
       - dl-base
     extends: dl-base
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
     command: >
       bash -c "
       conda run -n pytorch-gpu python -c 'import torch;print(torch.__version__);import intel_extension_for_pytorch as ipex;print(ipex.__version__);'

--- a/preset/deep-learning-pytorch-gpu/tests.yaml
+++ b/preset/deep-learning-pytorch-gpu/tests.yaml
@@ -15,23 +15,23 @@
 ---
 deep-learning-ipex-${PYTHON_VERSION:-3.11}-gpu:
   cmd: conda run -n pytorch-gpu python -W ignore sample-tests/intel_extension_for_pytorch/test_ipex.py --device xpu --ipex
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   device: ["/dev/dri"]
   user: root
 inference-optimization-inc-torch-${PYTHON_VERSION:-3.11}-gpu:
   cmd: conda run -n pytorch-gpu sample-tests/neural_compressor/run.sh xpu
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   device: ["/dev/dri"]
   user: root
 deep-learning-ipex-notebook-${PYTHON_VERSION:-3.11}-gpu:
   cmd: papermill --log-output jupyter/ipex/ResNet50_Inference.ipynb -k pytorch-gpu
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   notebook: True
   device: ["/dev/dri"]
   user: root
 deep-learning-ipex-quantization-notebook-${PYTHON_VERSION:-3.11}-gpu:
   cmd: papermill --log-output jupyter/ipex-quantization/IntelPytorch_Quantization.ipynb -k pytorch-gpu
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-pytorch-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   device: ["/dev/dri"]
   notebook: True
   user: root

--- a/preset/deep-learning-tensorflow-cpu/Dockerfile
+++ b/preset/deep-learning-tensorflow-cpu/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update -y && \
         xz-utils \
     && \
     rm -rf /var/lib/apt/lists/*
+RUN apt-get remove libexpat1 -y
 
 ##########################
 # Setting up non-root directories

--- a/preset/deep-learning-tensorflow-cpu/Dockerfile
+++ b/preset/deep-learning-tensorflow-cpu/Dockerfile
@@ -76,6 +76,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
         'jupyterlab>=4.2.6' \
         'notebook>=7.1.3' \
         'nb_conda_kernels>=2.5.1' \
+        'libexpat>=2.7.0' \
     && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
     && \
@@ -113,6 +114,7 @@ RUN conda create -yn 'tensorflow-cpu' \
         "tensorflow=${TF_VERSION}" \
         'tensorflow-hub>=0.16.1' \
         "onnxruntime=${ONNXRUNTIME_VERSION}" \
+        'libexpat>=2.7.0' \
         && \
     conda clean -y --all
 

--- a/preset/deep-learning-tensorflow-cpu/docker-compose.yaml
+++ b/preset/deep-learning-tensorflow-cpu/docker-compose.yaml
@@ -98,7 +98,7 @@ services:
     depends_on:
       - dl-base
     extends: dl-base
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
     command: >
       bash -c "
       conda run -n tensorflow-cpu python -c 'import tensorflow;print(tensorflow.__version__);import intel_extension_for_tensorflow as itex;print(itex.__version__)'

--- a/preset/deep-learning-tensorflow-cpu/tests.yaml
+++ b/preset/deep-learning-tensorflow-cpu/tests.yaml
@@ -15,17 +15,17 @@
 ---
 deep-learning-itex-${PYTHON_VERSION:-3.11}-cpu:
   cmd: conda run -n tensorflow-cpu python -W ignore sample-tests/intel_extension_for_tensorflow/test_itex.py
-  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
 import-itex-${PYTHON_VERSION:-3.11}-cpu:
   cmd: conda run -n tensorflow-cpu python -c "from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"
-  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
 inference-optimization-inc-tensorflow-${PYTHON_VERSION:-3.11}-cpu:
   cmd: conda run -n tensorflow-cpu sample-tests/neural_compressor/run.sh cpu
-  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
 inference-optimization-inc-itex-notebook-${PYTHON_VERSION:-3.11}-cpu:
   cmd: papermill --log-output jupyter/inc-itex/inc_sample_tensorflow.ipynb result.ipynb -k tensorflow-cpu --cwd jupyter/inc-itex
-  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   notebook: True
 inference-optimization-onnx-${PYTHON_VERSION:-3.11}-cpu:
   cmd: conda run -n tensorflow-cpu sample-tests/onnx/run.sh
-  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-cpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}

--- a/preset/deep-learning-tensorflow-gpu/Dockerfile
+++ b/preset/deep-learning-tensorflow-gpu/Dockerfile
@@ -104,6 +104,7 @@ RUN apt-get install -y --no-install-recommends --fix-missing \
         level-zero-dev="${LEVEL_ZERO_DEV_VER}" \
     && \
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/*list
+RUN apt-get remove libexpat1 -y
 
 ##########################
 # Setting up non-root directories
@@ -185,7 +186,6 @@ RUN conda create -yn 'tensorflow-gpu' \
         'libexpat>=2.7.0' \
         && \
     conda clean -y --all
-
 
 EXPOSE 8888
 

--- a/preset/deep-learning-tensorflow-gpu/Dockerfile
+++ b/preset/deep-learning-tensorflow-gpu/Dockerfile
@@ -232,7 +232,6 @@ RUN apt-get install -y --no-install-recommends --fix-missing \
     mkdir -p /var/run/sshd \
     && \
     echo 'LoginGraceTime 0' >> /etc/ssh/sshd_config
-RUN apt-get remove libexpat1 -y
 
 # https://github.com/openucx/ucx/issues/4742#issuecomment-584059909
 ENV UCX_TLS=ud,sm,self

--- a/preset/deep-learning-tensorflow-gpu/Dockerfile
+++ b/preset/deep-learning-tensorflow-gpu/Dockerfile
@@ -232,6 +232,7 @@ RUN apt-get install -y --no-install-recommends --fix-missing \
     mkdir -p /var/run/sshd \
     && \
     echo 'LoginGraceTime 0' >> /etc/ssh/sshd_config
+RUN apt-get remove libexpat1 -y
 
 # https://github.com/openucx/ucx/issues/4742#issuecomment-584059909
 ENV UCX_TLS=ud,sm,self

--- a/preset/deep-learning-tensorflow-gpu/Dockerfile
+++ b/preset/deep-learning-tensorflow-gpu/Dockerfile
@@ -134,6 +134,7 @@ RUN wget --progress=dot:giga --no-check-certificate "https://github.com/conda-fo
         'jupyterlab>=4.2.6' \
         'notebook>=7.1.3' \
         'nb_conda_kernels>=2.5.1' \
+        'libexpat>=2.7.0' \
     && \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" \
     && \
@@ -181,6 +182,7 @@ RUN conda create -yn 'tensorflow-gpu' \
         'matplotlib-base>=3.10.1' \
         "tensorflow=${TF_VERSION}" \
         'tensorflow-hub>=0.16.1' \
+        'libexpat>=2.7.0' \
         && \
     conda clean -y --all
 

--- a/preset/deep-learning-tensorflow-gpu/docker-compose.yaml
+++ b/preset/deep-learning-tensorflow-gpu/docker-compose.yaml
@@ -136,7 +136,7 @@ services:
     depends_on:
       - dl-base
     extends: dl-base
-    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+    image: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
     command: >
       bash -c "
       conda run -n tensorflow-gpu python -c 'from tensorflow.python.client import device_lib;print(device_lib.list_local_devices())'

--- a/preset/deep-learning-tensorflow-gpu/tests.yaml
+++ b/preset/deep-learning-tensorflow-gpu/tests.yaml
@@ -15,13 +15,13 @@
 ---
 deep-learning-itex-${PYTHON_VERSION:-3.11}-gpu:
   cmd: conda run -n tensorflow-gpu python -W ignore sample-tests/intel_extension_for_tensorflow/test_itex.py
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   device: ["/dev/dri"]
   user: root
 import-itex-${PYTHON_VERSION:-3.11}-gpu:
   cmd: conda run -n tensorflow-gpu python -c "from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   device: ["/dev/dri"]
 inference-optimization-inc-tensorflow-${PYTHON_VERSION:-3.11}-gpu:
   cmd: conda run -n tensorflow-gpu sample-tests/neural_compressor/run.sh cpu
-  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.0}-py${PYTHON_VERSION:-3.11}
+  img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}

--- a/preset/deep-learning-tensorflow-gpu/tests.yaml
+++ b/preset/deep-learning-tensorflow-gpu/tests.yaml
@@ -17,7 +17,7 @@ deep-learning-itex-${PYTHON_VERSION:-3.11}-gpu:
   cmd: conda run -n tensorflow-gpu python -W ignore sample-tests/intel_extension_for_tensorflow/test_itex.py
   img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}
   device: ["/dev/dri"]
-  user: root
+  privileged: true
 import-itex-${PYTHON_VERSION:-3.11}-gpu:
   cmd: conda run -n tensorflow-gpu python -c "from tensorflow.python.client import device_lib; print(device_lib.list_local_devices())"
   img: ${REGISTRY}/${REPO}:b-${GITHUB_RUN_NUMBER:-0}-deep-learning-tensorflow-gpu-${RELEASE:-2025.1.1}-py${PYTHON_VERSION:-3.11}


### PR DESCRIPTION
## Description
- Bump from libexpat 2.6.4 to 2.7.0  to pick up fix for https://nvd.nist.gov/vuln/detail/CVE-2024-8176
- changes for patch release 2025.1.1

## Validation
<!-- Explain how the changes have been tested, including the testing environment and any relevant test cases. -->

- [x] I have tested any changes in container groups locally with [`test_runner.py`](https://github.com/intel/ai-containers/blob/main/test-runner/README.md) with all existing tests passing, and I have added new tests where applicable.
